### PR TITLE
Fix regex for LENGTH

### DIFF
--- a/LexisNexis parser
+++ b/LexisNexis parser
@@ -35,7 +35,7 @@ for i in content:
     title = title[3].replace('\n',' ')
     
     #find the text
-    text = re.split('LENGTH:\s\d+\s+words', i)
+    text = re.split('LENGTH:\s\d+\s+[a-zA-Z]ords', i)
     text = text[1].split('LOAD-DATE: ')
     text = text[0].replace('\n',' ')
     


### PR DESCRIPTION
Lexis Nexis sometimes uses 'words' or 'Words' for the Length variable. A simple change to the regex command will account for both usages.